### PR TITLE
fix: Switch to fine grained PAT for pipeline.

### DIFF
--- a/.github/workflows/release-template.yml
+++ b/.github/workflows/release-template.yml
@@ -52,4 +52,4 @@ jobs:
         if: ${{ inputs.push_mirror == true }}
         run: |
           git subtree split --prefix=${{ inputs.folder }} --branch temp-mirror
-          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ inputs.mirror_repository }}.git temp-mirror:${{ inputs.mirror_branch }} --force
+          git push https://x-access-token:${{ secrets.MIRROR_TOKEN }}@github.com/${{ inputs.mirror_repository }}.git temp-mirror:${{ inputs.mirror_branch }} --force


### PR DESCRIPTION
# Description

This PR makes the pipeline now use a fine-grained PAT instead of the default `GITHUB_TOKEN`.